### PR TITLE
Problem when generating code for mapping a prim. array field

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/BeanWrapper.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/BeanWrapper.java
@@ -16,6 +16,13 @@
  */
 package fr.xebia.extras.selma.codegen;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -23,7 +30,6 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
-import java.util.*;
 
 /**
  * Wrapper for specific type
@@ -140,7 +146,7 @@ public class BeanWrapper {
     }
 
     public String getOutGetterPathFor(String field) {
-        return String.format("out.%s", getGetterFor(field));
+        return String.format("out.%s()", getGetterFor(field));
     }
 
     public String getGetterFor(String field) {

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
@@ -16,15 +16,44 @@
  */
 package fr.xebia.extras.selma.codegen;
 
-import javax.lang.model.element.*;
-import javax.lang.model.type.*;
-import javax.lang.model.util.ElementFilter;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.arrayCopy;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.assign;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.assignOutPrime;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.blank;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.controlNotNull;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.controlNullElse;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapArrayBis;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapCollection;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapDefaultCase;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapEnumBlock;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapEnumCase;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.mapMap;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.set;
+import static fr.xebia.extras.selma.codegen.MappingSourceNode.statement;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
-
-import static fr.xebia.extras.selma.codegen.MappingSourceNode.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
 
 /**
  *
@@ -325,7 +354,7 @@ public abstract class MappingBuilder {
                     MappingSourceNode buildNodes(MapperGeneratorContext context, SourceNodeVars vars) throws IOException {
 
                         root.body(vars.setOrAssign(String.format("new %s[%%s.length]", inOutType.inArrayComponentType())))
-                            .child(arrayCopy(vars.inGetter(), vars.outSetterPath()));
+                                .child(arrayCopy(vars.inGetter(), vars.outFieldGetter));
 
                         return root.body;
                     }


### PR DESCRIPTION
MappingBuilder was generating "out.setter" as destination parameter of
statement "System.arrayCopy..." when mapping array of primitive typed
field. It is likely that this solution isn't the most proper one
(acessing vars.outFieldGetter directly from MappingBuilder), because I
found the assignments in SourceNodeVars constructor a bit confusing. In
line 50, for instance, there is an assignment of an outSetterPathFor to
the field "outField", which sounds weird. Anyway, if you provide me more
information regarding these assignments, I can provide a more elegant
solution to the problem.