### PR TITLE
erreur de mapping si plusieurs variables avec le même type ont le même préfixe (startWith)

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
@@ -22,8 +22,11 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -223,7 +226,15 @@ public class MapperMethodGenerator {
                     customFields.addAll(customFieldsFor);
                     continue;
                 } else {
-                    outFieldName = customFieldsFor.get(0).to;
+		    final Comparator<Field> comparator = new Comparator<Field>() {
+			@Override
+			public int compare(final Field o1, final Field o2) {
+			    return o1.to.length() - o2.to.length();
+			}
+		    };
+		    Field min = Collections.min(customFieldsFor, comparator);
+		    outFieldName = min.to;
+		    //outFieldName = customFieldsFor.get(0).to;
                 }
             }
 

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/IbanRest.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/IbanRest.java
@@ -1,0 +1,33 @@
+package fr.xebia.extras.selma.beans;
+
+public class IbanRest {
+
+    private Integer codeBanque;
+
+    private Integer codeBanqueDomiciliation;
+
+    public IbanRest() {
+
+    }
+    
+    public IbanRest(Integer codeBanque, Integer codeBanqueDomiciliation) {
+	this.codeBanque = codeBanque;
+	this.codeBanqueDomiciliation = codeBanqueDomiciliation;
+    }
+
+    public Integer getCodeBanque() {
+	return codeBanque;
+    }
+
+    public void setCodeBanque(final Integer codeBanque) {
+	this.codeBanque = codeBanque;
+    }
+
+    public Integer getCodeBanqueDomiciliation() {
+	return codeBanqueDomiciliation;
+    }
+
+    public void setCodeBanqueDomiciliation(final Integer codeBanqueDomiciliation) {
+	this.codeBanqueDomiciliation = codeBanqueDomiciliation;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/Rib.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/Rib.java
@@ -1,0 +1,34 @@
+package fr.xebia.extras.selma.beans;
+
+public class Rib {
+
+    private Integer codeBanque;
+
+    private Integer codeBanqueCompensation;
+
+    public Rib() {
+
+    }
+    
+    public Rib(Integer codeBanque, Integer codeBanqueCompensation) {
+	this.codeBanque = codeBanque;
+	this.codeBanqueCompensation = codeBanqueCompensation;
+    }
+
+    public Integer getCodeBanque() {
+	return codeBanque;
+    }
+
+    public void setCodeBanque(final Integer codeBanque) {
+	this.codeBanque = codeBanque;
+    }
+
+    public Integer getCodeBanqueCompensation() {
+	return codeBanqueCompensation;
+    }
+
+    public void setCodeBanqueCompensation(final Integer codeBanqueCompensation) {
+	this.codeBanqueCompensation = codeBanqueCompensation;
+    }
+
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/IbanMapperIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/IbanMapperIT.java
@@ -1,0 +1,40 @@
+package fr.xebia.extras.selma.it;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import fr.xebia.extras.selma.Selma;
+import fr.xebia.extras.selma.beans.IbanRest;
+import fr.xebia.extras.selma.beans.Rib;
+import fr.xebia.extras.selma.it.mappers.IbanMapper;
+import fr.xebia.extras.selma.it.utils.Compile;
+import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
+
+@Compile(withClasses = { IbanMapper.class })
+public class IbanMapperIT extends IntegrationTestBase {
+
+    @Test
+    public void startWith_Iban_to_Rib_Test() {
+	final IbanMapper mapper = Selma.mapper(IbanMapper.class);
+
+	IbanRest ibanRest = new IbanRest(12, 25);
+
+	Rib rib = mapper.convert(ibanRest);
+
+	Assert.assertEquals(ibanRest.getCodeBanque(), rib.getCodeBanque());
+	Assert.assertEquals(ibanRest.getCodeBanqueDomiciliation(), rib.getCodeBanqueCompensation());
+    }
+
+    @Test
+    public void startWith_Rib_to_Iban_Test() {
+	final IbanMapper mapper = Selma.mapper(IbanMapper.class);
+	
+	Rib rib= new Rib(12,25);
+
+	IbanRest ibanRest = mapper.convert(rib);
+	
+	Assert.assertEquals(ibanRest.getCodeBanque(), rib.getCodeBanque());
+	Assert.assertEquals(ibanRest.getCodeBanqueDomiciliation(), rib.getCodeBanqueCompensation());
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/mappers/IbanMapper.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/mappers/IbanMapper.java
@@ -1,0 +1,14 @@
+package fr.xebia.extras.selma.it.mappers;
+
+import fr.xebia.extras.selma.Field;
+import fr.xebia.extras.selma.Mapper;
+import fr.xebia.extras.selma.beans.IbanRest;
+import fr.xebia.extras.selma.beans.Rib;
+
+@Mapper(withCustomFields = { @Field({ "IbanRest.codeBanque", "Rib.codeBanque" }), @Field({ "IbanRest.codeBanqueDomiciliation", "Rib.codeBanqueCompensation" }), })
+public interface IbanMapper {
+
+    IbanRest convert(Rib rib);
+
+    Rib convert(IbanRest iban);
+}


### PR DESCRIPTION
reproduction du bug :
si on a la premiere entitée :
IbanRest
contenant 2 variables avec le même type :
    - Integer codeBanque
    - Integer codeBanqueDomiciliation
    
et la seconde entitée :
Rib
contenant 2 variables avec le même type :
    - Integer codeBanque;
    - Integer codeBanqueCompensation;
    
chaque variable commence par "codeBanque" et si on utilise un
customFields, selma n'arrivera pas à mapper codeBanque car sa recherche
s'effectue avec un startWith.

Le test IbanMapperIT permet de reproduire le problème.