### PR TITLE
 #70: do not replace the .class in the package names.

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/CustomMapperWrapper.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/CustomMapperWrapper.java
@@ -168,7 +168,7 @@ public class CustomMapperWrapper {
 
             for (String customMapper : customClasses) {
 
-                final TypeElement element = context.elements.getTypeElement(customMapper.replace(".class", ""));
+                final TypeElement element = context.elements.getTypeElement(customMapper.replaceAll("\\.class$", ""));
 
                 mappingMethodCount += collectCustomMethods(element, false);
 


### PR DESCRIPTION
Fix the regex to replace only the .class at the end of the line.
closes #70