### PR TITLE
Add to way to specify the name of spring service

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperClassGenerator.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperClassGenerator.java
@@ -20,17 +20,16 @@ import com.squareup.javawriter.JavaWriter;
 import fr.xebia.extras.selma.IoC;
 import fr.xebia.extras.selma.SelmaConstants;
 
-import javax.annotation.Resource;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.util.*;
 
-import static javax.lang.model.element.Modifier.*;
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PUBLIC;
 
 /**
  * Handles the generation of the Mapper class
@@ -112,7 +111,11 @@ public class MapperClassGenerator {
                 writer.emitPackage(packageName);
                 writer.emitEmptyLine();
                 if (mapper.ioC == IoC.SPRING){
-                    writer.emitAnnotation("org.springframework.stereotype.Service");
+                    if (mapper.ioCServiceName !="") {
+                        writer.emitAnnotation("org.springframework.stereotype.Service","\""+mapper.ioCServiceName+"\"");
+                    }else{
+                        writer.emitAnnotation("org.springframework.stereotype.Service");
+                    }
                 }
                 openClassBlock(writer, adapterName, strippedTypeName);
                 writer.emitEmptyLine();

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperWrapper.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperWrapper.java
@@ -39,6 +39,7 @@ public class MapperWrapper {
     public static final String WITH_IGNORE_MISSING = "withIgnoreMissing";
     public static final String WITH_IOC = "withIoC";
     public static final String WITH_COLLECTION_STRATEGY = "withCollectionStrategy";
+    public static final String WITH_IOC_SERVICE_NAME="withIoCServiceName";
 
     private final FieldsWrapper fields;
     private final SourceConfiguration configuration;
@@ -53,6 +54,7 @@ public class MapperWrapper {
     private final SourceWrapper source;
     private final IgnoreMissing ignoreMissing;
     final IoC ioC;
+    final String ioCServiceName;
     private final CollectionMappingStrategy collectionMappingStrategy;
     private final boolean abstractClass;
 
@@ -83,7 +85,7 @@ public class MapperWrapper {
         }
 
         ioC = IoC.valueOf(mapper.getAsString(WITH_IOC));
-
+        ioCServiceName =mapper.getAsString(WITH_IOC_SERVICE_NAME);
         collectionMappingStrategy = CollectionMappingStrategy.valueOf(mapper.getAsString(WITH_COLLECTION_STRATEGY));
 
         fields = new FieldsWrapper(context, mapperInterface, mapper);

--- a/processor/src/test/java/fr/xebia/extras/selma/it/inject/AddressMapperWithName.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/inject/AddressMapperWithName.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013  Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package fr.xebia.extras.selma.it.inject;
+
+import fr.xebia.extras.selma.IoC;
+import fr.xebia.extras.selma.Mapper;
+import fr.xebia.extras.selma.beans.AddressIn;
+import fr.xebia.extras.selma.beans.AddressOut;
+
+/**
+ * Created by slemesle on 25/03/15.
+ */
+@Mapper(withIgnoreFields = "extras", withCustom =  CustomImmutableMapperClass.class, withIoC = IoC.SPRING,withIoCServiceName = "addressSelmaMapper")
+public interface AddressMapperWithName {
+
+    AddressOut asAddressOut(AddressIn in);
+
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/inject/CustomMapperUsingSpringIoCWithServiceNameIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/inject/CustomMapperUsingSpringIoCWithServiceNameIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013  Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package fr.xebia.extras.selma.it.inject;
+
+import fr.xebia.extras.selma.it.utils.Compile;
+import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+
+@Compile(withClasses = {AddressMapperWithName.class, CustomImmutableMapperClass.class})
+public class CustomMapperUsingSpringIoCWithServiceNameIT extends IntegrationTestBase {
+
+
+    @Test
+    public void given_mapper_name_as_selma_mapper_should_retrieve_it() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
+
+        ApplicationContext context = new AnnotationConfigApplicationContext(SpringConfiguration.class);
+        AddressMapperWithName addressMapperByName = (AddressMapperWithName) context.getBean("addressSelmaMapper");
+        Assert.assertNotNull(addressMapperByName);
+        AddressMapperWithName addressMapper = context.getBean(AddressMapperWithName.class);
+        Assert.assertEquals(addressMapper,addressMapperByName);
+    }
+
+}

--- a/selma/src/main/java/fr/xebia/extras/selma/Mapper.java
+++ b/selma/src/main/java/fr/xebia/extras/selma/Mapper.java
@@ -128,6 +128,12 @@ public @interface Mapper {
     IoC withIoC() default NO;
 
     /**
+     * define the name of the service that will be used with the Spring annotations.
+     * @return
+     */
+    String withIoCServiceName() default "";
+
+    /**
      * By default Selma uses a setter to provide new mapped collections. Passing this attribute to ALLOW_GETTER will
      * make Selma use a getter to map collections if the setter does not exist.
      */


### PR DESCRIPTION
We have to Mapper with the same name but in different package. As the two mappers use the withIOC attributes, we have an error when all the spring context is loaded because there is two beans with the same name.

This pull request try to resolve this issue.