### PR TITLE
Add a way to specify that I don't want null value to be mapped

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperGeneratorContext.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperGeneratorContext.java
@@ -37,6 +37,7 @@ public class MapperGeneratorContext {
 
     private final ProcessingEnvironment processingEnv;
     private final CompilerMessageRegistry messageRegistry;
+    private boolean ignoreNullValue=false;
     int depth = 0;
 
     Elements elements;
@@ -88,6 +89,14 @@ public class MapperGeneratorContext {
 
     public void warn(String s, ExecutableElement element) {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, s, messageRegistry.hasMessageFor(Diagnostic.Kind.WARNING, element) ? null : element);
+    }
+
+    public boolean isIgnoreNullValue() {
+        return ignoreNullValue;
+    }
+
+    public void setIgnoreNullValue(boolean ignoreNullValue) {
+        this.ignoreNullValue = ignoreNullValue;
     }
 
     /**

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperWrapper.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperWrapper.java
@@ -42,6 +42,7 @@ public class MapperWrapper {
     public static final String WITH_IOC = "withIoC";
     public static final String WITH_COLLECTION_STRATEGY = "withCollectionStrategy";
     public static final String WITH_IOC_SERVICE_NAME = "withIoCServiceName";
+    public static final String WITH_IGNORE_NULL_VALUE="withIgnoreNullValue";
 
     private final FieldsWrapper fields;
     private final SourceConfiguration configuration;
@@ -60,6 +61,7 @@ public class MapperWrapper {
     private final CollectionMappingStrategy collectionMappingStrategy;
     private final boolean abstractClass;
     private final FactoryWrapper factory;
+    private boolean ignoreNullValue;
 
     public MapperWrapper(MapperGeneratorContext context, TypeElement mapperInterface) {
         this.context = context;
@@ -93,7 +95,8 @@ public class MapperWrapper {
 
         fields = new FieldsWrapper(context, mapperInterface, mapper);
         mappingRegistry.fields(fields);
-
+        ignoreNullValue=mapper.getAsBoolean(WITH_IGNORE_NULL_VALUE);
+        context.setIgnoreNullValue(ignoreNullValue);
         // Here we collect custom mappers
         customMappers = new CustomMapperWrapper(mapper, context);
         mappingRegistry.customMappers(customMappers);

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
@@ -548,7 +548,13 @@ public abstract class MappingBuilder {
             }
             return root;
         } else {
-            return buildNodes(context, vars);
+            if (context.isIgnoreNullValue() && !vars.isOutPrimitive()){
+                root = notNullInField(vars);
+                root.body(ptr);
+                return root;
+            }else {
+                return buildNodes(context, vars);
+            }
         }
     }
 

--- a/processor/src/test/java/fr/xebia/extras/selma/it/NotNullValueMapperIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/NotNullValueMapperIT.java
@@ -1,0 +1,37 @@
+package fr.xebia.extras.selma.it;
+
+import fr.xebia.extras.selma.beans.CityIn;
+import fr.xebia.extras.selma.beans.CityOut;
+import fr.xebia.extras.selma.it.mappers.NotNullMapper;
+import fr.xebia.extras.selma.it.utils.Compile;
+import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static fr.xebia.extras.selma.Selma.builder;
+
+@Compile(withClasses =  {
+        NotNullMapper.class
+})
+public class NotNullValueMapperIT extends IntegrationTestBase{
+
+    @Test
+    public void test_should_not_map__null_value(){
+        NotNullMapper mapper = builder(NotNullMapper.class).build();
+        CityOut cityOut=new CityOut();
+        cityOut.setName("Name");
+        cityOut=mapper.mapCity(new CityIn(),cityOut);
+        Assert.assertEquals(cityOut.getName(),"Name");
+    }
+
+    @Test
+    public void test_should_map_not_null_value(){
+        NotNullMapper mapper = builder(NotNullMapper.class).build();
+        CityOut cityOut=new CityOut();
+        cityOut.setName("Name");
+        CityIn cityIn = new CityIn();
+        cityIn.setName("City");
+        cityOut=mapper.mapCity(cityIn,cityOut);
+        Assert.assertEquals(cityOut.getName(),"City");
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/mappers/NotNullMapper.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/mappers/NotNullMapper.java
@@ -1,0 +1,10 @@
+package fr.xebia.extras.selma.it.mappers;
+
+import fr.xebia.extras.selma.Mapper;
+import fr.xebia.extras.selma.beans.CityIn;
+import fr.xebia.extras.selma.beans.CityOut;
+
+@Mapper(withIgnoreNullValue = true)
+public interface NotNullMapper {
+    CityOut mapCity(CityIn cityIn, CityOut out);
+}

--- a/selma/src/main/java/fr/xebia/extras/selma/Mapper.java
+++ b/selma/src/main/java/fr/xebia/extras/selma/Mapper.java
@@ -117,6 +117,13 @@ public @interface Mapper {
      */
     String[] withIgnoreFields() default {};
 
+
+
+    /**
+     * This is used to not copy field with a null value
+     */
+    boolean withIgnoreNullValue() default false;
+
     /**
      * This is used to describe specific field to field mapping. If you need field "toto" to be mapped to "tutu", you should add
      * a @Field annotation here.
@@ -145,5 +152,6 @@ public @interface Mapper {
      * make Selma use a getter to map collections if the setter does not exist.
      */
      CollectionMappingStrategy withCollectionStrategy() default CollectionMappingStrategy.DEFAULT;
+
 
 }


### PR DESCRIPTION
Hi,

We need a specific configuration of selma which permit to not copy null value. This is usefull in case of a PATCH operation (for example) where not all field are presents. With this configuration, we maps (in update mode)  only the value passed. The null value are ignored.

Regards