### PR TITLE
Fix #97: Add support for mapping to raw types.

### DIFF
--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperGeneratorContext.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperGeneratorContext.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.PrimitiveType;
@@ -102,10 +101,21 @@ public class MapperGeneratorContext {
         };
     }
 
+    public void error(Element element, String templateMessage, Object... args) {
+        message(Diagnostic.Kind.ERROR, element, templateMessage, args);
+    }
 
-    public void error(Element element, String message, Object... args) {
+    public void warn(Element element, String templateMessage, Object... args) {
+        message(Diagnostic.Kind.WARNING, element, templateMessage, args);
+    }
 
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, String.format(message, args), messageRegistry.hasMessageFor(Diagnostic.Kind.ERROR, element) ? null : element);
+    private void message(Diagnostic.Kind kind, Element element, String templateMessage, Object... args) {
+        if (messageRegistry.hasMessageFor(kind, element)) {
+            // jdk7 treats a null element as a valid element too, so later messages with null get lost
+            processingEnv.getMessager().printMessage(kind, String.format(templateMessage, args));
+        } else {
+            processingEnv.getMessager().printMessage(kind, String.format(templateMessage, args), element);
+        }
     }
 
     public void pushStackForBody(MappingSourceNode node, SourceNodeVars vars) {
@@ -121,10 +131,6 @@ public class MapperGeneratorContext {
             return stack.pop();
         }
         return null;
-    }
-
-    public void warn(String s, ExecutableElement element) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, s, messageRegistry.hasMessageFor(Diagnostic.Kind.WARNING, element) ? null : element);
     }
 
     public boolean isIgnoreNullValue() {
@@ -209,10 +215,6 @@ public class MapperGeneratorContext {
 
     public Types types() {
         return type;
-    }
-
-    public void warn(Element element, String templateMessage, Object... args) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, String.format(templateMessage, args), messageRegistry.hasMessageFor(Diagnostic.Kind.WARNING, element) ? null : element);
     }
 
     public void setNewParams(String newParams) {

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
@@ -179,7 +179,7 @@ public class MapperMethodGenerator {
                 "--> Add a custom mapper or 'withIgnoreFields' on @Mapper or @Maps to fix this ! If you think this a Bug in Selma please report issue here [https://github.com/xebia-france/selma/issues].", inOutType.in(), inOutType.out(), mapperMethod.element().getEnclosingElement(), mapperMethod.element().toString());
         ptr.body(notSupported(message));
         if (configuration.isIgnoreNotSupported()) {
-            context.warn(message, mapperMethod.element());
+            context.warn(mapperMethod.element(), message);
         } else {
             context.error(mapperMethod.element(), message);
         }

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MapperMethodGenerator.java
@@ -198,11 +198,16 @@ public class MapperMethodGenerator {
             InOutType inOutType = stackElem.sourceNodeVars().inOutType;
             context.depth++;
             MappingBuilder mappingBuilder = findBuilderFor(inOutType);
-            if (stackElem.child) {
+            if (mappingBuilder != null) {
+                if (stackElem.child) {
 
-                stackElem.lastNode.lastChild().child(mappingBuilder.build(context, stackElem.sourceNodeVars()));
+                    stackElem.lastNode.lastChild().child(mappingBuilder.build(context, stackElem.sourceNodeVars()));
+                } else {
+                    stackElem.lastNode.body(mappingBuilder.build(context, stackElem.sourceNodeVars()));
+                }
             } else {
-                stackElem.lastNode.body(mappingBuilder.build(context, stackElem.sourceNodeVars()));
+                // just overwrite the whole node
+                handleNotSupported(inOutType, stackElem.lastNode);
             }
             context.depth--;
         }
@@ -304,7 +309,9 @@ public class MapperMethodGenerator {
                     handleNotSupported(inOutTypeForField, ptr);
                 }
             } catch (Exception e) {
-                System.out.printf("Error while searching builder for field %s on %s mapper", field, inOutType.toString());
+                // javac processingEnv.messager() tends to trim after the first line, so print stack trace too
+                context.error(mapperMethod.element(), "Error while searching builder for field %s on %s mapper: %s",
+                        field, inOutType.toString(), e.toString());
                 e.printStackTrace();
             }
 
@@ -447,7 +454,9 @@ public class MapperMethodGenerator {
                 handleNotSupported(inOutType, ptr);
             }
         } catch (Exception e) {
-            System.out.printf("Error while searching builder for field %s on %s mapper", field, inOutType.toString());
+            // javac processingEnv.messager() tends to trim after the first line, so print stack trace too
+            context.error(mapperMethod.element(), "Error while searching builder for field %s on %s mapper: %s",
+                    field, inOutType.toString(), e.toString());
             e.printStackTrace();
         }
 

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingBuilder.java
@@ -276,14 +276,18 @@ public abstract class MappingBuilder {
         // Map collections
         mappingSpecificationList.add(new MappingSpecification() {
             @Override boolean match(final MapperGeneratorContext context, final InOutType inOutType) {
-
-                return inOutType.areDeclared() && isCollection(inOutType.inAsDeclaredType(), context) && isCollection(inOutType.outAsDeclaredType(), context);
+                return inOutType.areDeclared() &&
+                        isCollection(inOutType.inAsDeclaredType(), context) &&
+                        isCollection(inOutType.outAsDeclaredType(), context) &&
+                        // can't map a raw input type
+                        getTypeArgument(context, inOutType.inAsDeclaredType(), 0) != null;
             }
 
             @Override MappingBuilder getBuilder(final MapperGeneratorContext context, final InOutType inOutType) {
 
                 // We have a collection
                 final TypeMirror genericIn = getTypeArgument(context, inOutType.inAsDeclaredType(), 0);
+                assert genericIn != null; // should have been filtered out by match()
                 final TypeMirror genericOut = getTypeArgument(context, inOutType.outAsDeclaredType(), 0);
                 // emit writer loop for collection and choose an implementation
                 String impl;
@@ -291,7 +295,8 @@ public abstract class MappingBuilder {
                     // Use given class for collection
                     impl = inOutType.out().toString();
                 } else {
-                    impl = CollectionsRegistry.findImplementationForType(inOutType.outAsTypeElement()) + "<" + genericOut.toString() + ">";
+                    impl = CollectionsRegistry.findImplementationForType(inOutType.outAsTypeElement()) +
+                            (genericOut == null ? "" : "<" + genericOut.toString() + ">");
                 }
                 final String implementation = impl;
                 TypeElement outElement = context.elements().getTypeElement(impl.replaceAll("<.*>", ""));
@@ -327,11 +332,16 @@ public abstract class MappingBuilder {
                             node.child(vars.setOrAssign(tmpVar));
                         }
                         context.pushStackForBody(node,
-                                new SourceNodeVars().withInOutType(new InOutType(genericIn, genericOut, false))
+                                new SourceNodeVars().withInOutType(createInOutType())
                                                     .withInField(itemVar)
                                                     .withOutField(String.format("%s.add", tmpVar)).withAssign(false).withIndexPtr(vars.nextPtr()));
 
                         return root.body;
+                    }
+
+                    private InOutType createInOutType() {
+                        TypeMirror out = genericOut == null ? context.getObjectType() : genericOut;
+                        return new InOutType(genericIn, out, false);
                     }
                 };
             }
@@ -345,6 +355,10 @@ public abstract class MappingBuilder {
                 final TypeMirror genericOutKey = getTypeArgument(context, inOutType.outAsDeclaredType(), 0);
                 final TypeMirror genericInValue = getTypeArgument(context, inOutType.inAsDeclaredType(), 1);
                 final TypeMirror genericOutValue = getTypeArgument(context, inOutType.outAsDeclaredType(), 1);
+                assert genericInKey != null && genericInValue != null; // should have been filtered out by match()
+                if (genericOutKey != null && genericOutValue == null) {
+                    throw new IllegalStateException("genericOutKey is non-null but genericOutValue is null");
+                }
 
                 // emit writer loop for collection and choose an implementation
                 String impl;
@@ -353,7 +367,8 @@ public abstract class MappingBuilder {
                     impl = inOutType.out().toString();
 
                 } else {
-                    impl = CollectionsRegistry.findImplementationForType(inOutType.outAsTypeElement()) + "<" + genericOutKey.toString() + ", " + genericOutValue.toString() + ">";
+                    impl = CollectionsRegistry.findImplementationForType(inOutType.outAsTypeElement()) +
+                            (genericOutKey == null ? "" : "<" + genericOutKey.toString() + ", " + genericOutValue.toString() + ">");
                 }
                 final String implementation = impl;
 
@@ -367,22 +382,35 @@ public abstract class MappingBuilder {
                         MappingSourceNode node = root.body(assign(String.format("%s %s", implementation, tmpVar), String.format("new %s()", implementation)))
                                                      .child(vars.setOrAssign(tmpVar))
                                                      .child(mapMap(itemVar, genericInKey.toString(), genericInValue.toString(), vars.inGetter()))
-                                                     .body(assign(String.format("%s %s", genericOutKey, keyVar), "null"));
-                        context.pushStackForChild(node, new SourceNodeVars().withInOutType(new InOutType(genericInValue, genericOutValue, false))
+                                                     .body(assign(String.format("%s %s", genericOutKey == null ? "Object" : genericOutKey, keyVar), "null"));
+                        context.pushStackForChild(node, new SourceNodeVars().withInOutType(createInOutType(genericInValue, genericOutValue))
                                                                             .withInField(String.format("%s.getValue()", itemVar)).withInFieldPrefix(String.format("%s,", keyVar))
                                                                             .withOutField(String.format("%s.put", tmpVar))
                                                                             .withAssign(false).withIndexPtr(vars.nextPtr()));
-                        context.pushStackForChild(node, new SourceNodeVars().withInOutType(new InOutType(genericInKey, genericOutKey, false))
+                        context.pushStackForChild(node, new SourceNodeVars().withInOutType(createInOutType(genericInKey, genericOutKey))
                                                                             .withInField(String.format("%s.getKey()", itemVar))
                                                                             .withOutField(keyVar)
                                                                             .withAssign(true).withIndexPtr(vars.nextPtr()));
                         return root.body;
                     }
+
+                    private InOutType createInOutType(TypeMirror in, TypeMirror out) {
+                        if (out == null) {
+                            out = context.getObjectType();
+                        }
+
+                        return new InOutType(in, out, false);
+                    }
                 };
             }
 
             @Override boolean match(final MapperGeneratorContext context, final InOutType inOutType) {
-                return inOutType.areDeclared() && isMap(inOutType.inAsDeclaredType(), context) && isMap(inOutType.outAsDeclaredType(), context);
+                return inOutType.areDeclared() &&
+                        isMap(inOutType.inAsDeclaredType(), context) &&
+                        isMap(inOutType.outAsDeclaredType(), context) &&
+                        // can't meaningfully map a raw Map
+                        getTypeArgument(context, inOutType.inAsDeclaredType(), 0) != null &&
+                        getTypeArgument(context, inOutType.inAsDeclaredType(), 1) != null;
             }
         });
 
@@ -446,6 +474,25 @@ public abstract class MappingBuilder {
             }
         });
 
+        // Mapping assignable value types
+        mappingSpecificationList.add(new MappingSpecification() {
+            @Override MappingBuilder getBuilder(final MapperGeneratorContext context, final InOutType inOutType) {
+
+                return new MappingBuilder(true) {
+                    @Override
+                    MappingSourceNode buildNodes(MapperGeneratorContext context, SourceNodeVars vars) throws IOException {
+                        root.body(vars.setOrAssign("%s"));
+                        return root.body;
+                    }
+                };
+            }
+
+            @Override boolean match(final MapperGeneratorContext context, final InOutType inOutType) {
+                return context.types().isAssignable(inOutType.in(), inOutType.out()) &&
+                        context.isValueType(inOutType.in());
+            }
+        });
+
     }
 
     private static boolean isMatchingPrimitiveToBoxed(InOutType inOutType, MapperGeneratorContext context) {
@@ -498,6 +545,10 @@ public abstract class MappingBuilder {
     }
 
     public static MappingBuilder getBuilderFor(final MapperGeneratorContext context, final InOutType inOutType) {
+        if (context.types().isSameType(context.getObjectType(), inOutType.in())) {
+            // can never build a useful Mapper if the input type is Object
+            return null;
+        }
 
         MappingBuilder res = null;
         for (MappingSpecification specification : mappingSpecificationList) {
@@ -685,7 +736,7 @@ public abstract class MappingBuilder {
      * @return
      */
     private static TypeMirror getTypeArgument(final MapperGeneratorContext context, TypeMirror type, final int index) {
-        TypeMirror param = type.accept(new SimpleTypeVisitor6<TypeMirror, Void>() {
+        return type.accept(new SimpleTypeVisitor6<TypeMirror, Void>() {
             @Override
             public TypeMirror visitDeclared(DeclaredType t, Void p) {
                 if (t.getTypeArguments().size() > 0) {
@@ -695,12 +746,6 @@ public abstract class MappingBuilder {
                 return getTypeArgument(context, superclass, index);
             }
         }, null);
-
-        if (param != null) {
-            return param;
-        }
-
-        return null;
     }
 
     static public <T> List<T> intersection(List<T> list1, List<T> list2) {
@@ -728,7 +773,6 @@ public abstract class MappingBuilder {
             }
         };
     }
-
 
     static abstract class MappingSpecification {
 

--- a/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingSourceNode.java
+++ b/processor/src/main/java/fr/xebia/extras/selma/codegen/MappingSourceNode.java
@@ -239,8 +239,9 @@ public abstract class MappingSourceNode {
         return new MappingSourceNode() {
             @Override
             void writeNode(JavaWriter writer) throws IOException {
-                writer.emitJavadoc("Throw notSupportedExeption because we failed to generate the mapping code: \n" + message);
-                writer.emitStatement("throw new UnsupportedOperationException(\"%s\")", message);
+                writer.emitJavadoc("Throw UnsupportedOperationException because we failed to generate the mapping code:\n" + message);
+                // new lines in message result in uncompilable code.
+                writer.emitStatement("throw new UnsupportedOperationException(\"%s\")", message.replace("\n", " "));
             }
         };
     }
@@ -284,7 +285,7 @@ public abstract class MappingSourceNode {
             @Override
             void writeNode(JavaWriter writer) throws IOException {
                 //for ( java.util.Map.Entry<java.lang.String,java.lang.String> _inEntry  : inType.entrySet())
-                writer.beginControlFlow(String.format("for (java.util.Map.Entry<%s,%s> %s : %s.entrySet())", keyType, valueType, itemVar, inField));
+                writer.beginControlFlow("for (java.util.Map.Entry<%s,%s> %s : %s.entrySet())", keyType, valueType, itemVar, inField);
                 writeBody(writer);
                 writer.endControlFlow();
             }

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawBean.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawBean.java
@@ -1,0 +1,37 @@
+package fr.xebia.extras.selma.beans;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Christopher Ng
+ */
+public class RawBean {
+    private Object object;
+    private List rawList;
+    private Map rawMap;
+
+    public Object getObject() {
+        return object;
+    }
+
+    public void setObject(Object object) {
+        this.object = object;
+    }
+
+    public List getRawList() {
+        return rawList;
+    }
+
+    public void setRawList(List rawList) {
+        this.rawList = rawList;
+    }
+
+    public Map getRawMap() {
+        return rawMap;
+    }
+
+    public void setRawMap(Map rawMap) {
+        this.rawMap = rawMap;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawBean.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawBean.java
@@ -1,15 +1,7 @@
 package fr.xebia.extras.selma.beans;
 
-import java.util.List;
-import java.util.Map;
-
-/**
- * @author Christopher Ng
- */
 public class RawBean {
     private Object object;
-    private List rawList;
-    private Map rawMap;
 
     public Object getObject() {
         return object;
@@ -17,21 +9,5 @@ public class RawBean {
 
     public void setObject(Object object) {
         this.object = object;
-    }
-
-    public List getRawList() {
-        return rawList;
-    }
-
-    public void setRawList(List rawList) {
-        this.rawList = rawList;
-    }
-
-    public Map getRawMap() {
-        return rawMap;
-    }
-
-    public void setRawMap(Map rawMap) {
-        this.rawMap = rawMap;
     }
 }

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawCollectionBeanDestination.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawCollectionBeanDestination.java
@@ -1,0 +1,25 @@
+package fr.xebia.extras.selma.beans;
+
+import java.util.List;
+import java.util.Map;
+
+public class RawCollectionBeanDestination {
+    private List stringList;
+    private Map intMap;
+
+    public Map getIntMap() {
+        return intMap;
+    }
+
+    public void setIntMap(Map intMap) {
+        this.intMap = intMap;
+    }
+
+    public List getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List stringList) {
+        this.stringList = stringList;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawCollectionBeanSource.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawCollectionBeanSource.java
@@ -1,0 +1,25 @@
+package fr.xebia.extras.selma.beans;
+
+import java.util.List;
+import java.util.Map;
+
+public class RawCollectionBeanSource {
+    private List<String> stringList;
+    private Map<Integer, String> intMap;
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public Map<Integer, String> getIntMap() {
+        return intMap;
+    }
+
+    public void setIntMap(Map<Integer, String> intMap) {
+        this.intMap = intMap;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawListBean.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawListBean.java
@@ -1,0 +1,15 @@
+package fr.xebia.extras.selma.beans;
+
+import java.util.List;
+
+public class RawListBean {
+    private List rawList;
+
+    public List getRawList() {
+        return rawList;
+    }
+
+    public void setRawList(List rawList) {
+        this.rawList = rawList;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/beans/RawMapBean.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/beans/RawMapBean.java
@@ -1,0 +1,15 @@
+package fr.xebia.extras.selma.beans;
+
+import java.util.Map;
+
+public class RawMapBean {
+    private Map rawMap;
+
+    public Map getRawMap() {
+        return rawMap;
+    }
+
+    public void setRawMap(Map rawMap) {
+        this.rawMap = rawMap;
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/FailingRawBeanMapperIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/FailingRawBeanMapperIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 Xebia and Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package fr.xebia.extras.selma.it.collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import fr.xebia.extras.selma.beans.RawBean;
+import fr.xebia.extras.selma.it.utils.Compile;
+import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
+import org.junit.Test;
+
+/**
+ *
+ */
+@Compile(withClasses = RawBeanMapper.class, shouldFail = true)
+public class FailingRawBeanMapperIT extends IntegrationTestBase {
+
+    @Test
+    public void compilation_should_fail_on_object_type() throws Exception {
+        assertCompilationError(RawBeanMapper.class,
+                "RawBean clone(RawBean rawBean);",
+                String.format("Failed to generate mapping method for type java.lang.Object to java.lang.Object not " +
+                        "supported on fr.xebia.extras.selma.it.collection.RawBeanMapper.clone(%s) !",
+                        RawBean.class.getName()));
+        assertThat(compilationErrorCount(), equalTo(3));
+    }
+
+    @Test
+    public void compilation_should_fail_on_raw_collection() throws Exception {
+        assertCompilationError(RawBeanMapper.class,
+                "RawBean clone(RawBean rawBean);",
+                String.format("Failed to generate mapping method for type java.util.List to java.util.List not supported " +
+                        "on fr.xebia.extras.selma.it.collection.RawBeanMapper.clone(%s) !",
+                        RawBean.class.getName()));
+        assertThat(compilationErrorCount(), equalTo(3));
+    }
+
+    @Test
+    public void compilation_should_fail_on_raw_map() throws Exception {
+        assertCompilationError(RawBeanMapper.class,
+                "RawBean clone(RawBean rawBean);",
+                String.format("Failed to generate mapping method for type java.util.Map to java.util.Map not supported " +
+                                "on fr.xebia.extras.selma.it.collection.RawBeanMapper.clone(%s) !",
+                        RawBean.class.getName()));
+        assertThat(compilationErrorCount(), equalTo(3));
+    }
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/FailingRawBeanMapperIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/FailingRawBeanMapperIT.java
@@ -20,12 +20,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import fr.xebia.extras.selma.beans.RawBean;
+import fr.xebia.extras.selma.beans.RawListBean;
+import fr.xebia.extras.selma.beans.RawMapBean;
 import fr.xebia.extras.selma.it.utils.Compile;
 import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
 import org.junit.Test;
 
 /**
- *
+ * Has to be split into multiple mapper classes as JDK7 doesn't reliably print all the compiler error messages.
  */
 @Compile(withClasses = RawBeanMapper.class, shouldFail = true)
 public class FailingRawBeanMapperIT extends IntegrationTestBase {
@@ -43,20 +45,20 @@ public class FailingRawBeanMapperIT extends IntegrationTestBase {
     @Test
     public void compilation_should_fail_on_raw_collection() throws Exception {
         assertCompilationError(RawBeanMapper.class,
-                "RawBean clone(RawBean rawBean);",
+                "RawListBean clone(RawListBean rawBean);",
                 String.format("Failed to generate mapping method for type java.util.List to java.util.List not supported " +
                         "on fr.xebia.extras.selma.it.collection.RawBeanMapper.clone(%s) !",
-                        RawBean.class.getName()));
+                        RawListBean.class.getName()));
         assertThat(compilationErrorCount(), equalTo(3));
     }
 
     @Test
     public void compilation_should_fail_on_raw_map() throws Exception {
         assertCompilationError(RawBeanMapper.class,
-                "RawBean clone(RawBean rawBean);",
+                "RawMapBean clone(RawMapBean rawBean);",
                 String.format("Failed to generate mapping method for type java.util.Map to java.util.Map not supported " +
                                 "on fr.xebia.extras.selma.it.collection.RawBeanMapper.clone(%s) !",
-                        RawBean.class.getName()));
+                        RawMapBean.class.getName()));
         assertThat(compilationErrorCount(), equalTo(3));
     }
 }

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawBeanMapper.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawBeanMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 Xebia and Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package fr.xebia.extras.selma.it.collection;
+
+import fr.xebia.extras.selma.Mapper;
+import fr.xebia.extras.selma.beans.RawBean;
+
+/**
+ *
+ */
+@Mapper
+public interface RawBeanMapper {
+    RawBean clone(RawBean rawBean);
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawBeanMapper.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawBeanMapper.java
@@ -18,11 +18,18 @@ package fr.xebia.extras.selma.it.collection;
 
 import fr.xebia.extras.selma.Mapper;
 import fr.xebia.extras.selma.beans.RawBean;
+import fr.xebia.extras.selma.beans.RawListBean;
+import fr.xebia.extras.selma.beans.RawMapBean;
 
 /**
- *
+ * Have to use separate methods (and thus beans) as JDK7 doesn't reliably print multiple compile errors from the same
+ * compilation method (ie the clone() methods).
  */
 @Mapper
 public interface RawBeanMapper {
     RawBean clone(RawBean rawBean);
+
+    RawListBean clone(RawListBean rawBean);
+
+    RawMapBean clone(RawMapBean rawBean);
 }

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawCollectionMapper.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawCollectionMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013 Xebia and Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package fr.xebia.extras.selma.it.collection;
+
+import fr.xebia.extras.selma.Mapper;
+import fr.xebia.extras.selma.beans.RawCollectionBeanDestination;
+import fr.xebia.extras.selma.beans.RawCollectionBeanSource;
+
+/**
+ *
+ */
+@Mapper
+public interface RawCollectionMapper {
+    RawCollectionBeanDestination asParameterizedToRawCollectionBeanDestination(RawCollectionBeanSource source);
+}

--- a/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawCollectionMapperIT.java
+++ b/processor/src/test/java/fr/xebia/extras/selma/it/collection/RawCollectionMapperIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013  Séven Le Mesle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package fr.xebia.extras.selma.it.collection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import fr.xebia.extras.selma.Selma;
+import fr.xebia.extras.selma.beans.RawCollectionBeanDestination;
+import fr.xebia.extras.selma.beans.RawCollectionBeanSource;
+import fr.xebia.extras.selma.it.utils.Compile;
+import fr.xebia.extras.selma.it.utils.IntegrationTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ */
+@Compile(withClasses = RawCollectionMapper.class)
+public class RawCollectionMapperIT extends IntegrationTestBase {
+    private RawCollectionMapper mapper;
+    private RawCollectionBeanSource source;
+
+    @Before
+    public void before() {
+        mapper = Selma.builder(RawCollectionMapper.class).build();
+        source = new RawCollectionBeanSource();
+        List<String> stringList = new ArrayList<String>();
+        stringList.add("param1");
+        stringList.add("param2");
+        source.setStringList(stringList);
+
+        Map<Integer, String> intMap = new HashMap<Integer, String>();
+        intMap.put(2, "param2");
+        intMap.put(4, "param4");
+        intMap.put(6, "param6");
+        source.setIntMap(intMap);
+    }
+
+    @Test
+    public void should_populate_parameterized_to_raw() {
+        // When
+        final RawCollectionBeanDestination destination = mapper.asParameterizedToRawCollectionBeanDestination(source);
+
+        // Then
+        assertThat(destination, notNullValue());
+        assertThat(destination.getStringList(), equalTo((List) source.getStringList()));
+        assertThat(destination.getIntMap(), equalTo((Map) source.getIntMap()));
+    }
+}


### PR DESCRIPTION
https://github.com/xebia-france/selma/issues/97

- Add support for mapping to raw types.
- Make compilation fail with error on unexpected exceptions.
- Make compilation fail when mapping from Object or raw types.

I made the compilation fail when unexpected exceptions are thrown during processing, the NPEs caused by trying to map a raw type meant that the mapper ended up silently ignoring those fields.

I also made the compilation fail if the Mapper needs to map from java.lang.Object (or from a raw Collection or Map).  Reason being that Selma cannot do any sensible mapping in this case as it has no idea what properties the source type actually has.  Previously it seems that the generated mapper just turns everything into new Object(), which isn't very useful, and is probably not what users are expecting.

Unrelated, but there should probably be a coding standard for the import ordering.  Depending on what file I am editing, I have to make my IDE (Intellij) order the imports differently because there isn't a consistent format across the project, and I don't want to introduce 'noise' in the commit by reordering the imports.